### PR TITLE
Improve test stability

### DIFF
--- a/bsl/stream.py
+++ b/bsl/stream.py
@@ -803,7 +803,7 @@ class Stream(ContainsMixin, SetChannelsMixin):
                 data = np.hstack((data, refs), dtype=self.dtype)
 
             # roll and update buffers
-            self._buffer = np.roll(self._buffer, -data.shape[0], axis=0)
+            self._buffer = np.roll(self._buffer, -timestamps.size, axis=0)
             self._timestamps = np.roll(self._timestamps, -timestamps.size, axis=0)
             # fmt: off
             self._buffer[-timestamps.size :, :] = data[-self._timestamps.size :, :]  # noqa: E203, E501
@@ -821,6 +821,17 @@ class Stream(ContainsMixin, SetChannelsMixin):
                     "argument or consider retrieving new samples more often with "
                     "Stream.get_data()."
                 )
+        except ValueError as error:
+            logger.error("Data shape is %s", data.shape)
+            logger.error(
+                "Picks inlet has %s element (%s)",
+                self._picks_inlet.size,
+                self._picks_inlet,
+            )
+            logger.error("Ref channels are %s", self._ref_channels)
+            logger.exception(error)
+            self._reset_variables()
+            return None  # equivalent to an interrupt
         except Exception as error:
             logger.exception(error)
             self._reset_variables()


### PR DESCRIPTION
For some reason, with added reference channels, sometimes we get:

```
self._buffer[-timestamps.size :, :] = data[-self._timestamps.size :, :]  # noqa: E203, E501
ValueError: could not broadcast input array from shape (208,67) into shape (208,66)
```

Seems to be always caught by: https://github.com/fcbg-hnp-meeg/bsl/blob/742755cc5e8c813d59a2d0a50cfb2a270e486984/bsl/tests/test_stream.py#L328